### PR TITLE
Change 80-character limit to 100-character limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,10 +508,6 @@ to help risks not getting used at all &ndash; no matter how good it is.
     empty line between the comment block and the `def`.
 <sup>[[link](#rdoc-conventions)]</sup>
 
-* <a name="100-character-limits"></a>
-  Limit lines to 100 characters.
-<sup>[[link](#100-character-limits)]</sup>
-
 * <a name="no-trailing-whitespace"></a>
   Avoid trailing whitespace.
 <sup>[[link](#no-trailing-whitespace)]</sup>

--- a/README.md
+++ b/README.md
@@ -508,9 +508,9 @@ to help risks not getting used at all &ndash; no matter how good it is.
     empty line between the comment block and the `def`.
 <sup>[[link](#rdoc-conventions)]</sup>
 
-* <a name="80-character-limits"></a>
-  Limit lines to 80 characters.
-<sup>[[link](#80-character-limits)]</sup>
+* <a name="100-character-limits"></a>
+  Limit lines to 100 characters.
+<sup>[[link](#100-character-limits)]</sup>
 
 * <a name="no-trailing-whitespace"></a>
   Avoid trailing whitespace.


### PR DESCRIPTION
I have read a reasoning behind 80-character limit in the common ruby style guide. I agree that the limit itself makes sense, but I don't think we need to stick to 80 characters because "not everyone in the world has widescreens".

The practical limit I see is Github. It shows 101 character without horizontal scrolling, so I offer to stick to 100 characters, because scroll horizontally during code review sucks.

Two questions:
1. There were voices in Ruby community which advocated 80 character limit because some people use only part of their widescreen displays for IDE. Do we have anyone who does it and 80->100 difference will introduce significant inconvenience?
2. We need to think about exempts to this rule. For instance, long URLs?
